### PR TITLE
Refactor call usage

### DIFF
--- a/spec/interactor.spec.js
+++ b/spec/interactor.spec.js
@@ -58,7 +58,7 @@ describe('Interactor', () => {
     describe('when catchInteractorFailure false', () => {
       describe('when success', () => {
         it('returns context', async () => {
-          const { result } = await Interactor.call({ test: 1 }, false);
+          const { result } = await Interactor.call({ test: 1 }, { catchInteractorFailure: false });
 
           expect(result).toBeInstanceOf(Context);
 
@@ -76,7 +76,7 @@ describe('Interactor', () => {
             const interactor = buildInteractor(callFn, rollbackFn);
 
             try {
-              await interactor.call({ test: 1 }, false);
+              await interactor.call({ test: 1 }, { catchInteractorFailure: false });
             } catch (e) {
               expect(e).toBeInstanceOf(InteractorFailure);
               expect(e.name).toStrictEqual('InteractorFailure');
@@ -97,7 +97,7 @@ describe('Interactor', () => {
             const interactor = buildInteractor(callFn);
 
             try {
-              await interactor.call({ test: 1 }, false);
+              await interactor.call({ test: 1 }, { catchInteractorFailure: false });
             } catch (e) {
               expect(e).toBeInstanceOf(Error);
               expect(e.message).toStrictEqual('TestError');
@@ -124,7 +124,7 @@ describe('Interactor', () => {
         );
 
         try {
-          await failureInteractor.call(context, false);
+          await failureInteractor.call(context, { catchInteractorFailure: false });
         } catch (e) {
           expect(e.context.initialValue).toStrictEqual(true);
 
@@ -143,11 +143,16 @@ describe('Interactor', () => {
             throwsInteractorFailure: true,
           });
 
-          const { result: result1 } = await interactor1.call({ initialValue: true }, false);
-          const { result: result2 } = await interactor2.call(result1, false);
+          const { result: result1 } = await interactor1.call(
+            { initialValue: true },
+            { catchInteractorFailure: false },
+          );
+          const { result: result2 } = await interactor2.call(result1, {
+            catchInteractorFailure: false,
+          });
 
           try {
-            await failureInteractor.call(result2, false);
+            await failureInteractor.call(result2, { catchInteractorFailure: false });
           } catch (e) {
             assertRollbackContext(e.context);
           }
@@ -166,11 +171,16 @@ describe('Interactor', () => {
             throwsInteractorFailure: false,
           });
 
-          const { result: result1 } = await interactor1.call({ initialValue: true }, false);
-          const { result: result2 } = await interactor2.call(result1, false);
+          const { result: result1 } = await interactor1.call(
+            { initialValue: true },
+            { catchInteractorFailure: false },
+          );
+          const { result: result2 } = await interactor2.call(result1, {
+            catchInteractorFailure: false,
+          });
 
           try {
-            await failureInteractor.call(result2, false);
+            await failureInteractor.call(result2, { catchInteractorFailure: false });
           } catch (e) {}
 
           [result1, result2].forEach((result) => {

--- a/spec/interactor.spec.js
+++ b/spec/interactor.spec.js
@@ -5,102 +5,104 @@ import { assertRollbackContext } from './utils';
 
 describe('Interactor', () => {
   describe('call', () => {
-    describe('when success', () => {
-      it('returns context', async () => {
-        const { result } = await Interactor.call({ test: 1 });
-
-        expect(result).toBeInstanceOf(Context);
-
-        expect(result.test).toEqual(1);
-      });
-    });
-
-    describe('when failure', () => {
-      describe('when InteractorFailure error', () => {
-        it('throws with merged context', async () => {
-          expect.assertions(5);
-          const callFn = (context) => context.fail({ error: 'test' });
-          const rollbackFn = (context) => (context.rolledBack = true);
-
-          const interactor = buildInteractor(callFn, rollbackFn);
-
-          try {
-            await interactor.call({ test: 1 });
-          } catch (e) {
-            expect(e).toBeInstanceOf(InteractorFailure);
-            expect(e.name).toStrictEqual('InteractorFailure');
-            expect(e.context.error).toStrictEqual('test');
-            expect(e.context.test).toStrictEqual(1);
-            expect(e.context.rolledBack).toBeUndefined();
-          }
-        });
-      });
-
-      describe('when random error', () => {
-        it('throws', async () => {
+    describe('default', () => {
+      describe('when success', () => {
+        it('returns context', async () => {
           expect.assertions(2);
-          const callFn = () => {
-            throw new Error('TestError');
-          };
-
-          const interactor = buildInteractor(callFn);
-
-          try {
-            await interactor.call({ test: 1 });
-          } catch (e) {
-            expect(e).toBeInstanceOf(Error);
-            expect(e.message).toStrictEqual('TestError');
-          }
-        });
-      });
-    });
-  });
-
-  describe('safeCall', () => {
-    describe('when success', () => {
-      it('returns context', async () => {
-        expect.assertions(2);
-        const { result } = await Interactor.safeCall({ test: 1 });
-
-        expect(result).toBeInstanceOf(Context);
-
-        expect(result.test).toEqual(1);
-      });
-    });
-
-    describe('when failure', () => {
-      describe('when InteractorFailure', () => {
-        it('doesnt throw', async () => {
-          expect.assertions(4);
-          const callFn = (context) => context.fail({ error: 'test' });
-
-          const interactor = buildInteractor(callFn);
-
-          const { result } = await interactor.safeCall({ test: 1 });
+          const { result } = await Interactor.call({ test: 1 });
 
           expect(result).toBeInstanceOf(Context);
-          expect(result.isFailure()).toStrictEqual(true);
-          expect(result.test).toStrictEqual(1);
-          expect(result.error).toStrictEqual('test');
+
+          expect(result.test).toEqual(1);
         });
       });
 
-      describe('when any other error', () => {
-        it('throws', async () => {
-          expect.assertions(2);
+      describe('when failure', () => {
+        describe('when InteractorFailure', () => {
+          it('doesnt throw', async () => {
+            expect.assertions(4);
+            const callFn = (context) => context.fail({ error: 'test' });
 
-          const failure = () => {
-            throw new Error('TestError');
-          };
+            const interactor = buildInteractor(callFn);
 
-          const interactor = buildInteractor(failure);
+            const { result } = await interactor.call({ test: 1 });
 
-          try {
-            await interactor.safeCall({ test: 1 });
-          } catch (e) {
-            expect(e).toBeInstanceOf(Error);
-            expect(e.message).toStrictEqual('TestError');
-          }
+            expect(result).toBeInstanceOf(Context);
+            expect(result.isFailure()).toStrictEqual(true);
+            expect(result.test).toStrictEqual(1);
+            expect(result.error).toStrictEqual('test');
+          });
+        });
+
+        describe('when any other error', () => {
+          it('throws', async () => {
+            expect.assertions(2);
+
+            const failure = () => {
+              throw new Error('TestError');
+            };
+
+            const interactor = buildInteractor(failure);
+
+            try {
+              await interactor.call({ test: 1 });
+            } catch (e) {
+              expect(e).toBeInstanceOf(Error);
+              expect(e.message).toStrictEqual('TestError');
+            }
+          });
+        });
+      });
+    });
+
+    describe('when catchInteractorFailure false', () => {
+      describe('when success', () => {
+        it('returns context', async () => {
+          const { result } = await Interactor.call({ test: 1 }, false);
+
+          expect(result).toBeInstanceOf(Context);
+
+          expect(result.test).toEqual(1);
+        });
+      });
+
+      describe('when failure', () => {
+        describe('when InteractorFailure error', () => {
+          it('throws with merged context', async () => {
+            expect.assertions(5);
+            const callFn = (context) => context.fail({ error: 'test' });
+            const rollbackFn = (context) => (context.rolledBack = true);
+
+            const interactor = buildInteractor(callFn, rollbackFn);
+
+            try {
+              await interactor.call({ test: 1 }, false);
+            } catch (e) {
+              expect(e).toBeInstanceOf(InteractorFailure);
+              expect(e.name).toStrictEqual('InteractorFailure');
+              expect(e.context.error).toStrictEqual('test');
+              expect(e.context.test).toStrictEqual(1);
+              expect(e.context.rolledBack).toBeUndefined();
+            }
+          });
+        });
+
+        describe('when random error', () => {
+          it('throws', async () => {
+            expect.assertions(2);
+            const callFn = () => {
+              throw new Error('TestError');
+            };
+
+            const interactor = buildInteractor(callFn);
+
+            try {
+              await interactor.call({ test: 1 }, false);
+            } catch (e) {
+              expect(e).toBeInstanceOf(Error);
+              expect(e.message).toStrictEqual('TestError');
+            }
+          });
         });
       });
     });
@@ -122,7 +124,7 @@ describe('Interactor', () => {
         );
 
         try {
-          await failureInteractor.call(context);
+          await failureInteractor.call(context, false);
         } catch (e) {
           expect(e.context.initialValue).toStrictEqual(true);
 
@@ -141,11 +143,11 @@ describe('Interactor', () => {
             throwsInteractorFailure: true,
           });
 
-          const { result: result1 } = await interactor1.call({ initialValue: true });
-          const { result: result2 } = await interactor2.call(result1);
+          const { result: result1 } = await interactor1.call({ initialValue: true }, false);
+          const { result: result2 } = await interactor2.call(result1, false);
 
           try {
-            await failureInteractor.call(result2);
+            await failureInteractor.call(result2, false);
           } catch (e) {
             assertRollbackContext(e.context);
           }
@@ -164,11 +166,11 @@ describe('Interactor', () => {
             throwsInteractorFailure: false,
           });
 
-          const { result: result1 } = await interactor1.call({ initialValue: true });
-          const { result: result2 } = await interactor2.call(result1);
+          const { result: result1 } = await interactor1.call({ initialValue: true }, false);
+          const { result: result2 } = await interactor2.call(result1, false);
 
           try {
-            await failureInteractor.call(result2);
+            await failureInteractor.call(result2, false);
           } catch (e) {}
 
           [result1, result2].forEach((result) => {

--- a/spec/organizer.spec.js
+++ b/spec/organizer.spec.js
@@ -69,7 +69,7 @@ describe('Organizer', () => {
           const organizer = buildOrganizer(...interactors);
 
           try {
-            await organizer.call({ initialValue: true }, false);
+            await organizer.call({ initialValue: true }, { catchInteractorFailure: false });
           } catch (error) {
             assertRollbackContext(error.context);
           }

--- a/spec/organizer.spec.js
+++ b/spec/organizer.spec.js
@@ -50,18 +50,18 @@ describe('Organizer', () => {
   describe('rollback', () => {
     describe('single organizer', () => {
       describe('when InteractorFailure error', () => {
-        it('with safeCall', async () => {
+        it('with default', async () => {
           expect.assertions(8);
           const interactors = buildThreeInteractors({ throwsInteractorFailure: true });
 
           const organizer = buildOrganizer(...interactors);
 
-          const { result } = await organizer.safeCall({ initialValue: true });
+          const { result } = await organizer.call({ initialValue: true });
 
           assertRollbackContext(result);
         });
 
-        it('with call', async () => {
+        it('with catchInteractorFailure false', async () => {
           expect.assertions(8);
 
           const interactors = buildThreeInteractors({ throwsInteractorFailure: true });
@@ -69,7 +69,7 @@ describe('Organizer', () => {
           const organizer = buildOrganizer(...interactors);
 
           try {
-            await organizer.call({ initialValue: true });
+            await organizer.call({ initialValue: true }, false);
           } catch (error) {
             assertRollbackContext(error.context);
           }
@@ -77,7 +77,7 @@ describe('Organizer', () => {
       });
 
       describe('when Any other error', () => {
-        describe('with safeCall', () => {
+        describe('with default', () => {
           it('it throws', async () => {
             expect.assertions(8);
 
@@ -88,7 +88,7 @@ describe('Organizer', () => {
             const context = Context.build({ initialValue: true });
 
             try {
-              await organizer.safeCall(context);
+              await organizer.call(context);
             } catch (e) {
               expect(e.message).toStrictEqual('TestError');
 
@@ -97,7 +97,7 @@ describe('Organizer', () => {
           });
         });
 
-        describe('with call', () => {
+        describe('with catchInteractorFailure false', () => {
           it('it throws again', async () => {
             expect.assertions(8);
 
@@ -137,7 +137,7 @@ describe('Organizer', () => {
 
         const mainOrganizer = buildOrganizer(subOrganizer1, subOrganizer2, subOrganizer3);
 
-        const { result } = await mainOrganizer.safeCall({ called: [], rolledBack: [] });
+        const { result } = await mainOrganizer.call({ called: [], rolledBack: [] });
 
         expect(result.called).toStrictEqual([1, 2, 3, 4, 5, 6]);
 

--- a/spec/types/interactor.types.ts
+++ b/spec/types/interactor.types.ts
@@ -47,7 +47,7 @@ const testValid = async () => {
     numberInput: 1,
     strInput: 'str',
     boolInput: true,
-  });
+  }, false);
 
   boolTest(result.isFailure());
   boolTest(result.isSuccess());

--- a/spec/types/organizer.types.ts
+++ b/spec/types/organizer.types.ts
@@ -46,7 +46,7 @@ const testInvalid = async () => {
     strInput2: 2,
     boolInput1: 'true',
     boolInput2: 'false',
-  });
+  }, false);
 
   const dontExist: string = result.dontExist;
 

--- a/src/interactor.ts
+++ b/src/interactor.ts
@@ -11,20 +11,13 @@ interface InteractorResult<
 export type AnyObject = Record<string, any>;
 
 export class Interactor<Input extends AnyObject = AnyObject, Output extends AnyObject = AnyObject> {
-  static async safeCall(context = {}) {
-    const interactor = new this(context);
-
-    await interactor._safeRun();
-
-    return { result: interactor.context };
-  }
-
   static async call<Params extends AnyObject = AnyObject, Result extends AnyObject = AnyObject>(
     context: Params,
+    catchInteractorFailure: boolean = true,
   ): Promise<InteractorResult<Params, Result>> {
     const interactor: Interactor<Params, Result> = new this(context);
 
-    await interactor._run();
+    await interactor._run(catchInteractorFailure);
 
     return { result: interactor.context };
   }
@@ -35,22 +28,14 @@ export class Interactor<Input extends AnyObject = AnyObject, Output extends AnyO
     this.context = Context.build<Input & Output>(context);
   }
 
-  async _safeRun() {
-    try {
-      await this._run();
-    } catch (e) {
-      if (e instanceof InteractorFailure) return;
-
-      throw e;
-    }
-  }
-
-  async _run() {
+  async _run(catchInteractorFailure: boolean) {
     try {
       await this.call();
       this.context._markAsCalled(this);
     } catch (e) {
       await this.context._rollback();
+
+      if (catchInteractorFailure && e instanceof InteractorFailure) return;
 
       throw e;
     }

--- a/src/interactor.ts
+++ b/src/interactor.ts
@@ -13,7 +13,7 @@ export type AnyObject = Record<string, any>;
 export class Interactor<Input extends AnyObject = AnyObject, Output extends AnyObject = AnyObject> {
   static async call<Params extends AnyObject = AnyObject, Result extends AnyObject = AnyObject>(
     context: Params,
-    catchInteractorFailure: boolean = true,
+    { catchInteractorFailure } = { catchInteractorFailure: true },
   ): Promise<InteractorResult<Params, Result>> {
     const interactor: Interactor<Params, Result> = new this(context);
 

--- a/src/organizer.ts
+++ b/src/organizer.ts
@@ -1,7 +1,7 @@
-import { Interactor } from './interactor';
+import { AnyObject, Interactor } from './interactor';
 
 interface InteractorClassType extends Function {
-  new (...args: any[]): Interactor;
+  new (context: AnyObject): Interactor;
 }
 
 export class Organizer extends Interactor {
@@ -9,7 +9,7 @@ export class Organizer extends Interactor {
 
   async call(): Promise<void> {
     for (const InteractorClass of this.Interactors!) {
-      await InteractorClass.call(this.context);
+      await InteractorClass.call(this.context, false);
     }
   }
 }


### PR DESCRIPTION
### Before

```javascript
...
async call() {
  this.context.fail({ error: 'Error' })
}
...

// Safe call
const { result } = Interactor.safeCall({ foo: 'bar' })
-> result.isFailure() // -> ​true
-> result // -> Context { foo: 'bar', error: 'Error' }

// Default call
try {
 ​Interactor.call({ foo: 'bar' }) // -> Throws any error. If error is `InteractorFailure`, error has context field.
} catch(e) {
 ​e.context // -> Context { foo: 'bar', error: 'Error' }
}

```

### Now

Handling InteractorFailure is a default behaviour.
A second parameter can be passed to `call` to prevent catching InteractorFailure error.

```javascript
...
async call() {
  this.context.fail({ error: 'Error' })
}
...

// Call
const { result } = Interactor.call({ foo: 'bar' })
-> result.isFailure() // -> ​true
-> result // -> Context { foo: 'bar', error: 'Error' }

// Call with { catchInteractorFailure: false }
try {
 ​Interactor.call({ foo: 'bar' }, { catchInteractorFailure: false }) // -> Throws any error. If error is `InteractorFailure`, error has context field.
} catch(e) {
 ​e.context // -> Context { foo: 'bar', error: 'Error' }
}
```